### PR TITLE
Reduce back cover copy for 5x8 mockup

### DIFF
--- a/manuscript/back-cover.html
+++ b/manuscript/back-cover.html
@@ -20,10 +20,10 @@
         }
 
         .back-cover {
-            width: 5.5in;
-            height: 8.5in;
+            width: 5in;
+            height: 8in;
             background: #F5B800;
-            padding: 0.4in 0.4in;
+            padding: 0.35in 0.35in;
             display: flex;
             flex-direction: column;
             box-shadow: 0 4px 20px rgba(0,0,0,0.3);
@@ -228,30 +228,21 @@
         </div>
 
         <div class="opening">
-            Most lead buyers are playing a game they can't win. They buy volume,<br>
-            squeeze vendors on price, and hope the sales team figures it out.<br>
-            Meanwhile, cost per lead keeps climbing, contact rates keep falling, and<br>
-            compliance risk keeps growing.
+            Most lead buyers are playing a game they can't win—buying volume, squeezing vendors, and hoping sales figures it out. Meanwhile, costs climb, contact rates fall, and compliance risk grows.
         </div>
 
         <div class="pitch">
             <p class="intro-bold">This book will change the way you think about lead generation.</p>
 
-            <p>For twenty years, Bill Rice has been on both sides of the lead generation equation—building consumer direct systems for major lenders and running a lead generation agency. He's watched smart professionals burn through marketing budgets on bad data while competitors build systematic advantages that compound over time.</p>
-
-            <p><em>The Lead Buyer's Playbook</em> is the operational blueprint he wishes someone had handed him when he started. Inside, you'll discover:</p>
+            <p>For twenty years, Bill Rice has been on both sides of the lead generation equation—building consumer direct systems for major lenders and running a lead generation agency. <em>The Lead Buyer's Playbook</em> is the operational blueprint he wishes someone had handed him when he started. Inside:</p>
 
             <ul>
-                <li>Why the "more volume, lower price" strategy is mathematically broken</li>
+                <li>Why "more volume, lower price" is mathematically broken</li>
                 <li>How to hit 20%+ contact rates when industry average is 8%</li>
-                <li>The vendor management framework that turns adversaries into partners</li>
-                <li>Compliance systems that protect you from TCPA lawsuits</li>
                 <li>The 90-day action plan to transform your lead operation</li>
             </ul>
 
-            <p>This isn't theory. Every framework has been tested in the field with mortgage, insurance, legal, and home services companies—from startups buying their first leads to enterprises managing seven-figure monthly budgets.</p>
-
-            <p>The companies that master strategic lead generation don't just grow faster. They grow more predictably, more profitably, and more sustainably than competitors stuck in tactical procurement mode.</p>
+            <p>Every framework has been tested with mortgage, insurance, legal, and home services companies—from startups to enterprises managing seven-figure monthly budgets. Master strategic lead generation and grow more predictably, profitably, and sustainably than competitors stuck in tactical mode.</p>
         </div>
 
         <div class="tagline-section">
@@ -266,9 +257,8 @@
         <div class="about-section">
             <div class="about-text">
                 <h3>About Bill Rice</h3>
-                <p><strong>Bill Rice</strong> is a lead generation strategist who coined the term "lead management" and developed the mortgage industry's first intelligent lead scoring system.</p>
-                <p>As a founding member of DeepGreen Bank and an early innovator at Quicken Loans, Bill helped architect the digital origination models that defined the modern lending industry.</p>
-                <p>Today, as CEO of <strong>Kaleidico</strong>, a digital marketing agency specializing in lead generation for mortgage, legal, and senior living companies, he maintains a transparent view into exactly how leads are generated, packaged, and sold.</p>
+                <p><strong>Bill Rice</strong> coined the term "lead management" and developed the mortgage industry's first intelligent lead scoring system. A founding member of DeepGreen Bank and early innovator at Quicken Loans, he helped define modern digital lending.</p>
+                <p>Today, as CEO of <strong>Kaleidico</strong>, Bill maintains a transparent view into exactly how leads are generated, packaged, and sold.</p>
             </div>
             <img src="../img/bill-rice-author-photo.jpg" alt="Bill Rice" class="author-photo" onerror="this.style.display='none';this.nextElementSibling.style.display='flex';">
             <div class="author-photo-placeholder">Photo<br>Pending</div>

--- a/manuscript/back-cover.md
+++ b/manuscript/back-cover.md
@@ -10,7 +10,7 @@
 
 ## Opening Statement (Centered, Medium Text)
 
-Most lead buyers are playing a game they can't win. They buy volume, squeeze vendors on price, and hope the sales team figures it out. Meanwhile, cost per lead keeps climbing, contact rates keep falling, and compliance risk keeps growing.
+Most lead buyers are playing a game they can't win—buying volume, squeezing vendors, and hoping sales figures it out. Meanwhile, costs climb, contact rates fall, and compliance risk grows.
 
 ---
 
@@ -18,19 +18,13 @@ Most lead buyers are playing a game they can't win. They buy volume, squeeze ven
 
 This book will change the way you think about lead generation.
 
-For twenty years, Bill Rice has been on both sides of the lead generation equation—building consumer direct systems for major lenders and running a lead generation agency. He's watched smart professionals burn through marketing budgets on bad data while competitors build systematic advantages that compound over time.
+For twenty years, Bill Rice has been on both sides of the lead generation equation—building consumer direct systems for major lenders and running a lead generation agency. *The Lead Buyer's Playbook* is the operational blueprint he wishes someone had handed him when he started. Inside:
 
-*The Lead Buyer's Playbook* is the operational blueprint he wishes someone had handed him when he started. Inside, you'll discover:
-
-- Why the "more volume, lower price" strategy is mathematically broken
+- Why "more volume, lower price" is mathematically broken
 - How to hit 20%+ contact rates when industry average is 8%
-- The vendor management framework that turns adversaries into partners
-- Compliance systems that protect you from TCPA lawsuits
 - The 90-day action plan to transform your lead operation
 
-This isn't theory. Every framework has been tested in the field with mortgage, insurance, legal, and home services companies—from startups buying their first leads to enterprises managing seven-figure monthly budgets.
-
-The companies that master strategic lead generation don't just grow faster. They grow more predictably, more profitably, and more sustainably than competitors stuck in tactical procurement mode.
+Every framework has been tested with mortgage, insurance, legal, and home services companies—from startups to enterprises managing seven-figure monthly budgets. Master strategic lead generation and grow more predictably, profitably, and sustainably than competitors stuck in tactical mode.
 
 ---
 
@@ -48,13 +42,9 @@ The companies that master strategic lead generation don't just grow faster. They
 
 ![Bill Rice](images/bill-rice-author-photo.jpg)
 
-Bill Rice is a lead generation strategist who coined the term "lead management" and developed the mortgage industry's first intelligent lead scoring system.
+**Bill Rice** coined the term "lead management" and developed the mortgage industry's first intelligent lead scoring system. A founding member of DeepGreen Bank and early innovator at Quicken Loans, he helped define modern digital lending.
 
-As a founding member of DeepGreen Bank (one of the first internet-only banks) and an early innovator at Quicken Loans, Bill helped architect the digital origination models that defined the modern lending industry.
-
-Today, as CEO of **Kaleidico**, a digital marketing agency specializing in lead generation for mortgage, legal, and senior living companies, he maintains a transparent view into exactly how leads are generated, packaged, and sold.
-
-Bill applies the pattern recognition skills from his career as a U.S. Air Force intelligence officer to bring clarity to the complex lead marketplace. He publishes weekly analysis on growth strategy at **MyExecutiveBrief.com**.
+Today, as CEO of **Kaleidico**, Bill maintains a transparent view into exactly how leads are generated, packaged, and sold.
 
 ---
 


### PR DESCRIPTION
- Change dimensions from 5.5x8.5 to 5x8 inches
- Condense opening statement to fewer lines
- Reduce bullet points from 5 to 3 key items
- Combine closing paragraphs into one
- Shorten author bio from 4 paragraphs to 2
- Adjust padding for smaller format

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Condenses back-cover copy and updates HTML mockup to 5x8 with tighter padding; mirrors edits in markdown.
> 
> - **Back cover layout (`manuscript/back-cover.html`)**
>   - Resize `.back-cover` from `5.5in × 8.5in` to `5in × 8in`; reduce padding to `0.35in`.
>   - Tighten copy: shorter opening, combined pitch intro, bullet list trimmed to 3 items, closing condensed.
>   - Author bio shortened from multiple paragraphs to 2; minor wording simplifications.
> - **Content source (`manuscript/back-cover.md`)**
>   - Mirror condensed opening, pitch, and 3-item bullets.
>   - Combine closing into one paragraph; shorten author bio to 2 paragraphs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3cceda4242115239c32f5c89daf658458cae0a52. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->