### PR TITLE
Remove duplicate photo and style branding elements

### DIFF
--- a/manuscript/back-cover.html
+++ b/manuscript/back-cover.html
@@ -154,23 +154,6 @@
             align-self: flex-start;
         }
 
-        .author-photo-placeholder {
-            width: 1.1in;
-            height: 1.1in;
-            border-radius: 50%;
-            background: #e8e8e8;
-            border: 3px solid #fff;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.2);
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            font-size: 0.55rem;
-            color: #666;
-            text-align: center;
-            flex-shrink: 0;
-            align-self: flex-start;
-        }
-
         .footer {
             display: flex;
             justify-content: space-between;
@@ -192,9 +175,10 @@
         }
 
         .kaleidico-url {
-            font-size: 0.55rem;
-            color: #c41e3a;
+            font-size: 0.7rem;
+            color: #6B21A8;
             font-family: Arial, sans-serif;
+            font-weight: 600;
         }
 
         .isbn-area {
@@ -259,8 +243,7 @@
                 <h3>About Bill Rice</h3>
                 <p><strong>Bill Rice</strong> coined the term "lead management" and built the mortgage industry's first intelligent lead scoring system. An early innovator at Quicken Loans and founding member of DeepGreen Bank, he helped define modern digital lending. As CEO of <strong>Kaleidico</strong>, he sees exactly how leads are made and sold.</p>
             </div>
-            <img src="../img/bill-rice-author-photo.jpg" alt="Bill Rice" class="author-photo" onerror="this.style.display='none';this.nextElementSibling.style.display='flex';">
-            <div class="author-photo-placeholder">Photo<br>Pending</div>
+            <img src="../img/bill-rice-author-photo.jpg" alt="Bill Rice" class="author-photo">
         </div>
 
         <div class="footer">


### PR DESCRIPTION
- Remove duplicate author photo placeholder
- Update kaleidico.com URL to brand purple (#6B21A8)
- Increase URL font size for better visibility
- Clean up unused placeholder CSS

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the author photo placeholder (and onerror fallback) and updates `kaleidico.com` URL styling to brand purple with larger, bolder text.
> 
> - **Back cover (`manuscript/back-cover.html`)**:
>   - **About section**:
>     - Remove `.author-photo-placeholder` CSS and the placeholder element; drop `onerror` fallback on the author image.
>   - **Branding/footer**:
>     - Update `.kaleidico-url` styles: set `font-size` to `0.7rem`, `color` to `#6B21A8`, and add `font-weight: 600`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 56c8a15b654ba33003025f9f45645f0957d87874. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->